### PR TITLE
Correcciones del layout de las páginas home y paises

### DIFF
--- a/Paises/index.html
+++ b/Paises/index.html
@@ -1,70 +1,70 @@
 ---
 layout: page
-title: Podcast por Países 
+title: Podcast por Países
 description: "An archive of posts sorted by tag."
 comments: false
 ---
 
 
 	<article>
-	<h2>España</h2>
-	<ul>
-    {% for post in site.categories.Espana %}
-       {% cycle 'add row' : '<div class="row">', nil, nil %}
-        <div class="col-sm-4">
-            <div class="preview-panel">
-                <a href="{{ post.url | prepend: site.baseurl }}">
-                    <img src="{{ post.preview }}">
-                </a>
-               
-           </div>
-        </div>
-{% cycle 'end row' : nil, nil, '</div>' %}
-    {% endfor %}
-    {% cycle 'end row' : nil, '</div>', '</div>' %}
+		<h2>España</h2>
+
+		<ul>
+			<div class="row">
+		    {% for post in site.categories.Espana %}
+		        <div class="col-xs-6 col-sm-4">
+		            <div class="preview-panel">
+		                <a href="{{ post.url | prepend: site.baseurl }}">
+		                    <img src="{{ post.preview }}">
+		                </a>
+		           </div>
+		        </div>
+		    {% endfor %}
+			</div>
 		</ul>
-	</article><!-- /.hentry -->
-	
+
+	</article>
+
 	<br/>
 	<br/>
 
-<article>
-	<h2>Argentina</h2>
-	<ul>
-    {% for post in site.categories.Argentina %}
-      {% cycle 'add row' : '<div class="row">', nil, nil %}
-        <div class="col-sm-4">
-            <div class="preview-panel">
-                <a href="{{ post.url | prepend: site.baseurl }}">
-                    <img src="{{ post.preview }}">
-                </a>
-               
-           </div>
-        </div>
-{% cycle 'end row' : nil, nil, '</div>' %}
-    {% endfor %}
-    {% cycle 'end row' : nil, '</div>', '</div>' %}
-		</ul>
-	</article><!-- /.hentry -->
-	
-	<br/>
-	<br/>
-	
 	<article>
-	<h2>Venezuela</h2>
-	<ul>
-    {% for post in site.categories.Venezuela %}
-      {% cycle 'add row' : '<div class="row">', nil, nil %}
-        <div class="col-sm-4">
-            <div class="preview-panel">
-                <a href="{{ post.url | prepend: site.baseurl }}">
-                    <img src="{{ post.preview }}">
-                </a>
-               
-           </div>
-        </div>
-{% cycle 'end row' : nil, nil, '</div>' %}
-    {% endfor %}
-    {% cycle 'end row' : nil, '</div>', '</div>' %}
+		<h2>Argentina</h2>
+
+		<ul>
+			<div class="row">
+				{% for post in site.categories.Argentina %}
+						<div class="col-xs-6 col-sm-4">
+								<div class="preview-panel">
+										<a href="{{ post.url | prepend: site.baseurl }}">
+												<img src="{{ post.preview }}">
+										</a>
+							 </div>
+						</div>
+				{% endfor %}
+			</div>
 		</ul>
-	</article><!-- /.hentry -->
+
+	</article>
+
+	<br/>
+	<br/>
+
+	<article>
+		<h2>Venezuela</h2>
+
+		<ul>
+			<div class="row">
+				{% for post in site.categories.Venezuela %}
+						<div class="col-xs-6 col-sm-4">
+								<div class="preview-panel">
+										<a href="{{ post.url | prepend: site.baseurl }}">
+												<img src="{{ post.preview }}">
+										</a>
+							 </div>
+						</div>
+				{% endfor %}
+			</div>
+		</ul>
+
+	</article>

--- a/_includes/preview.html
+++ b/_includes/preview.html
@@ -1,13 +1,11 @@
-{% for post in site.posts %}
-    {% cycle 'add row' : '<div class="row">', nil, nil %}
-        <div class="col-sm-4">
-            <div class="preview-panel">
-                <a href="{{ post.url | prepend: site.baseurl }}">
-                    <img src="{{ post.preview }}">
-                </a>
-               
-           </div>
-        </div>
-{% cycle 'end row' : nil, nil, '</div>' %}
-{% endfor %}
-{% cycle 'end row' : nil, '</div>', '</div>' %}
+<div class="row">
+  {% for post in site.posts %}
+  <div class="col-xs-6 col-sm-4">
+    <div class="preview-panel">
+      <a href="{{ post.url | prepend: site.baseurl }}">
+        <img src="{{ post.preview }}">
+      </a>
+    </div>
+  </div>
+  {% endfor %}
+</div>


### PR DESCRIPTION
En ambas páginas he quitado los elementos {% cycle %}, ya que no aportaban nada. Y he añadido un layout de 2 columnas en vez de 3 para pantallas pequeñas, para que no se vean tan pequeñas las imágenes en dispositivos móviles.